### PR TITLE
Update the name of the docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This wallet uses a Sia wrapper that allows parts of Sia to be run directly in th
 
 ## Docker
 ```
-docker run -p 80:80 -d siacentral/sia-central-lite-wallet
+docker run -p 80:80 -d siacentral/sia-lite-wallet-web
 ```
 
 ## Project setup


### PR DESCRIPTION
Looks like the name of the docker image has changed, which caused this command to fail when blindly running it.

https://hub.docker.com/r/siacentral/sia-lite-wallet-web