### PR TITLE
Add reset wallet modal

### DIFF
--- a/src/components/ForgotPassword.vue
+++ b/src/components/ForgotPassword.vue
@@ -1,0 +1,66 @@
+<template>
+	<div class="page page-forgot">
+		<div class="page-content">
+			<h1 class="text-center text-error">{{ translate('resetWalletModal.heading') }}</h1>
+			<p>{{ translate('resetWalletModal.pExplain') }}</p>
+			<div class="confirm">
+				<div class="control">
+					<input type="checkbox" id="chk-reset-confirm" v-model="confirmed" />
+					<label class="text-error" for="chk-reset-confirm"> {{ translate('resetWalletModal.chkConfirm') }}</label>
+				</div>
+			</div>
+			<div class="buttons">
+				<button class="btn btn-inline" @click="$emit('close')">{{ translate('cancel') }}</button>
+				<button class="btn btn-danger btn-inline" @click="onReset" :disabled="!confirmed">{{ translate('resetWalletModal.btnDelete') }}</button>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { reset } from '@/store/db.js';
+import { mapActions } from 'vuex';
+
+export default {
+	data() {
+		return {
+			confirmed: false
+		};
+	},
+	methods: {
+		...mapActions(['setSetup']),
+		async onReset() {
+			try {
+				if (!this.confirmed)
+					return;
+
+				await reset();
+				this.setSetup(false);
+				this.$emit('close');
+			} catch (ex) {
+				console.error('unable to reset', ex);
+			}
+		}
+	}
+};
+</script>
+
+<style lang="stylus" scoped>
+.page-forgot {
+	position: fixed;
+	background: bg-dark;
+	z-index: 99;
+}
+
+.page-content {
+	display: grid;
+	height: 100%;
+	max-width: 700px;
+	margin: auto;
+	padding: 15px;
+	grid-gap: 15px;
+	align-content: safe center;
+	overflow-x: hidden;
+	overflow-y: auto;
+}
+</style>

--- a/src/store/db.js
+++ b/src/store/db.js
@@ -99,7 +99,7 @@ export function getAddresses(walletID, addresses) {
 	return db.getAddresses(walletID, addresses);
 }
 
-export async function getWalletChangeAddress(walletID) {
+export function getWalletChangeAddress(walletID) {
 	return db.getWalletChangeAddress(walletID);
 }
 
@@ -107,6 +107,10 @@ export function getLastWalletAddresses(walletID, limit, offset) {
 	return db.getLastWalletAddresses(walletID, limit, offset);
 }
 
-export async function deleteWallet(walletID) {
+export function deleteWallet(walletID) {
 	return db.deleteWallet(walletID);
+}
+
+export function reset() {
+	return db.reset();
 }

--- a/src/store/db/dexie.js
+++ b/src/store/db/dexie.js
@@ -75,4 +75,11 @@ export default class DexieStore {
 			this._db.wallets.filter(w => w.id === walletID).delete()
 		]);
 	}
+
+	reset() {
+		return Promise.all([
+			this._db.addresses.clear(),
+			this._db.wallets.clear()
+		]);
+	}
 }

--- a/src/store/db/memory.js
+++ b/src/store/db/memory.js
@@ -83,4 +83,9 @@ export default class MemoryStore {
 
 		delete this._wallets[walletID];
 	}
+
+	reset() {
+		this._wallets = {};
+		this._addresses = {};
+	}
 }

--- a/src/translation/languages/cn.json
+++ b/src/translation/languages/cn.json
@@ -106,6 +106,12 @@
 		"unlockWalletModal": {
 			"pWalletsLocked": "您的钱包目前已加密并锁定，输入密码解锁您的钱包并查看您的资金。"
 		},
+		"resetWalletModal": {
+			"heading": "Forgot Password?",
+			"pExplain": "Wallet data is stored locally and encrypted using your unlock password, there is no way to recover a forgotton password. This will delete all stored data and reset your password. After resetting you can recover your wallet using the recovery seed or import addresses from your Ledger Nano S.",
+			"chkConfirm": "I understand that all data will be permanently erased and I will lose access to my wallets",
+			"btnDelete": "Delete all data and reset"
+		},
 		"createWalletModal": {
 			"newWallet": "新建钱包",
 			"recoverWallet": "恢复钱包",

--- a/src/translation/languages/en.json
+++ b/src/translation/languages/en.json
@@ -106,6 +106,12 @@
 		"unlockWalletModal": {
 			"pWalletsLocked": "Your wallets are currently encrypted and locked. Enter your password to unlock your wallets and access your funds."
 		},
+		"resetWalletModal": {
+			"heading": "Forgot Password?",
+			"pExplain": "Wallet data is stored locally and encrypted using your unlock password, there is no way to recover a forgotton password. This will delete all stored data and reset your password. After resetting you can recover your wallet using the recovery seed or import addresses from your Ledger Nano S.",
+			"chkConfirm": "I understand that all data will be permanently erased and I will lose access to my wallets",
+			"btnDelete": "Delete all data and reset"
+		},
 		"createWalletModal": {
 			"newWallet": "New Wallet",
 			"recoverWallet": "Recover Wallet",

--- a/src/translation/languages/fr.json
+++ b/src/translation/languages/fr.json
@@ -106,6 +106,12 @@
 		"unlockWalletModal": {
 			"pWalletsLocked": "Vos portefeuilles sont encryptés et verrouillés. Entrez votre mot de passe pour débloquer vos portefeuilles et accéder à vos fonds."
 		},
+		"resetWalletModal": {
+			"heading": "Forgot Password?",
+			"pExplain": "Wallet data is stored locally and encrypted using your unlock password, there is no way to recover a forgotton password. This will delete all stored data and reset your password. After resetting you can recover your wallet using the recovery seed or import addresses from your Ledger Nano S.",
+			"chkConfirm": "I understand that all data will be permanently erased and I will lose access to my wallets",
+			"btnDelete": "Delete all data and reset"
+		},
 		"createWalletModal": {
 			"newWallet": "Nouveau portefeuille",
 			"recoverWallet": "Rétablir un portefeuille",

--- a/src/views/UnlockWallet.vue
+++ b/src/views/UnlockWallet.vue
@@ -13,19 +13,28 @@
 					<button class="btn btn-success btn-inline" :disabled="unlocking">{{ translate('unlock') }}</button>
 				</div>
 			</form>
+			<div class="buttons">
+				<button class="reset-button" @click.prevent="forgotPassword = true">Forgot Password?</button>
+			</div>
 			<p class="text-small text-secondary text-center">Version: {{ uiRevision }}</p>
 		</div>
+		<transition name="fade" mode="out-in">
+			<forgot-password v-if="forgotPassword" @close="forgotPassword = false" />
+		</transition>
 	</div>
 </template>
 
 <script>
 import { mapActions } from 'vuex';
+import ForgotPassword from '../components/ForgotPassword.vue';
 
 export default {
+	components: { ForgotPassword },
 	data() {
 		return {
 			password: '',
-			unlocking: false
+			unlocking: false,
+			forgotPassword: false
 		};
 	},
 	methods: {
@@ -92,5 +101,13 @@ h2, p {
 
 .text-secondary {
 	color: rgba(255, 255, 255, 0.24);
+}
+
+.reset-button {
+	color: rgba(255, 255, 255, 0.4);
+	background: none !important;
+	border: none !important;
+	outline: none !important;
+	cursor: pointer;
 }
 </style>


### PR DESCRIPTION
Closes #24

Adds a "Forgot Password" button to the unlock screen allowing users to delete all data and reset their wallets